### PR TITLE
Use error_prefix is available (for 360Giving error grouping)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2019-01-07
+## [Unreleased]
 
-### Added
+### Changed
+
+- Use error_prefix in validaiton error modal IDs, if available (for 360Giving error grouping) https://github.com/OpenDataServices/cove/issues/1117
+
+## [0.3.0] - 2019-01-07
 
 ### Added
 

--- a/cove/templates/validation_table.html
+++ b/cove/templates/validation_table.html
@@ -39,7 +39,11 @@
   {% endif %}
   <td class="text-center">
     {% if values|length > 3 %}
+      {% if error_prefix %}
+      <a data-toggle="modal" data-target=".{{"validation-errors-"|concat:error_prefix|concat:forloop.counter}}">
+      {% else %}
       <a data-toggle="modal" data-target=".{{"validation-errors-"|concat:forloop.counter}}">
+      {% endif %}
         {{values|length}}
       </a>
     {% else %}


### PR DESCRIPTION
This is required for
[OpenDataServices/cove#1117](https://github.com/OpenDataServices/cove/issues/1117)