### PR TITLE
Add fields file_name and created_time in explore_data_context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Fields `file_name` and `created_time` in explore_data_context.
+
 ## [0.5.0] - 2019-03-22
 
 ### Added

--- a/cove/tests.py
+++ b/cove/tests.py
@@ -1,0 +1,24 @@
+from cove.views import get_file_name
+
+def test_get_file_name_with_slash():
+    file_name = get_file_name('c8291024-155a-46fa-8af2-0b6a30b4686c/file_name_with_slash.xml')
+
+    assert file_name == 'file_name_with_slash.xml'
+
+
+def test_get_file_name_without_slash():
+    file_name = get_file_name('file_name_without_slash.xml')
+
+    assert file_name == 'file_name_without_slash.xml'
+
+
+def test_get_file_name_with_empty_string():
+    file_name = get_file_name('')
+
+    assert file_name == ''
+
+
+def test_get_file_name_with_none():
+    file_name = get_file_name(file_name=None)
+
+    assert file_name is None

--- a/cove/views.py
+++ b/cove/views.py
@@ -13,6 +13,12 @@ from libcove.lib.tools import get_file_type as _get_file_type
 logger = logging.getLogger(__name__)
 
 
+def get_file_name(file_name):
+    if file_name is not None and '/' in file_name:
+        file_name = file_name.split('/')[-1]
+    return file_name
+
+
 def explore_data_context(request, pk, get_file_type=None):
     if get_file_type is None:
         get_file_type = _get_file_type
@@ -49,12 +55,14 @@ def explore_data_context(request, pk, get_file_type=None):
             'path': data.original_file.path,
         },
         'file_type': file_type,
+        'file_name': get_file_name(file_name),
         'data_uuid': pk,
         'current_url': request.build_absolute_uri(),
         'source_url': data.source_url,
         'form_name': data.form_name,
         'created_datetime': data.created.strftime('%A, %d %B %Y %I:%M%p %Z'),
         'created_date': data.created.strftime('%A, %d %B %Y'),
+        'created_time': data.created.strftime('%I:%M%p %Z'),
     }
 
     return (context, data, None)


### PR DESCRIPTION
Related to plan.io ticket #15862
I have added these two fields to be able to display them in IATI cove data summary.