### PR TITLE
tests: Test against Django 3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.5' , '3.6']
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        django-version:
+          - "Django>=2.2,<2.3"
+          - "Django>=3.0,<3.1"
+          - "Django>=3.1,<3.2"
+          - "Django>=3.2,<3.3"
+        exclude:
+          # Django 3.1+ supports Python 3.9.
+          # https://docs.djangoproject.com/en/3.1/releases/3.1.3/
+          - python-version: "3.9"
+            django-version: "Django>=2.2,<2.3"
+          - python-version: "3.9"
+            django-version: "Django>=3.0,<3.1"
     steps:
       - uses: actions/checkout@v2
       - name: Setup python
@@ -22,6 +34,7 @@ jobs:
             ${{ runner.os }}-pip-
       - run: "pip install --upgrade pip"
       - run: "pip install --use-feature=2020-resolver --upgrade -e .[test]"
+      - run: "pip install ${{ matrix.django-version }}"
       - run: "DJANGO_SETTINGS_MODULE=cove.settings py.test -n 2 cove --cov --cov-report="
       # Install translate toolkit to get pocount binary
       - run: "sudo apt-get update"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-pip-
       - run: "pip install --upgrade pip"
       - run: "pip install --use-feature=2020-resolver --upgrade -e .[test]"
-      - run: "pip install ${{ matrix.django-version }}"
+      - run: "pip install '${{ matrix.django-version }}'"
       - run: "DJANGO_SETTINGS_MODULE=cove.settings py.test -n 2 cove --cov --cov-report="
       # Install translate toolkit to get pocount binary
       - run: "sudo apt-get update"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
       - run: "pip install --upgrade pip"
       - run: "pip install --use-feature=2020-resolver --upgrade -e .[test]"
       - run: "pip install '${{ matrix.django-version }}'"
-      - run: "DJANGO_SETTINGS_MODULE=cove.settings py.test -n 2 cove --cov"
+      - run: "py.test -n 2 cove --cov"
+        env:
+          PYTHONWARNINGS: error
+          DJANGO_SETTINGS_MODULE: cove.settings
+          SECRET_KEY: 7ur)dt+e%1^e6$8_sd-@1h67_5zixe2&39%r2$$8_7v6fr_7ee
       # Install translate toolkit to get pocount binary
       - run: "sudo apt-get update"
       - run: "sudo apt-get install translate-toolkit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - run: "pip install --upgrade pip"
       - run: "pip install --use-feature=2020-resolver --upgrade -e .[test]"
       - run: "pip install '${{ matrix.django-version }}'"
-      - run: "DJANGO_SETTINGS_MODULE=cove.settings py.test -n 2 cove --cov --cov-report="
+      - run: "DJANGO_SETTINGS_MODULE=cove.settings py.test -n 2 cove --cov"
       # Install translate toolkit to get pocount binary
       - run: "sudo apt-get update"
       - run: "sudo apt-get install translate-toolkit"

--- a/cove/html_error_msg.py
+++ b/cove/html_error_msg.py
@@ -2,7 +2,7 @@ import json
 
 from django.utils.html import conditional_escape, escape, format_html
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import ugettext_lazy as _, ngettext
+from django.utils.translation import gettext_lazy as _, ngettext
 
 from libcove.lib.tools import decimal_default
 

--- a/cove/html_error_msg.py
+++ b/cove/html_error_msg.py
@@ -21,7 +21,7 @@ except ImproperlyConfigured:
 validation_error_template_lookup_safe = {
     "date-time": _("Date is not in the correct format"),
     "uri": _("Invalid 'uri' found"),
-    "string": _("{}<code>{}</code> is not a string. Check that the value {} has quotes at the start and end. Escape any quotes in the value with <code>\</code>"),
+    "string": _("{}<code>{}</code> is not a string. Check that the value {} has quotes at the start and end. Escape any quotes in the value with <code>\\</code>"),
     "integer": _("{}<code>{}</code> is not a integer. Check that the value {} doesn’t contain decimal points or any characters other than 0-9. Integer values should not be in quotes. "),
     "number": _("{}<code>{}</code> is not a number. Check that the value {} doesn’t contain any characters other than 0-9 and dot (<code>.</code>). Number values should not be in quotes. "),
     "object": _("{}<code>{}</code> is not a JSON object"),

--- a/cove/input/views.py
+++ b/cove/input/views.py
@@ -4,7 +4,7 @@ from django import forms
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.shortcuts import render, redirect
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from cove.input.models import SuppliedData
 from django.views.decorators.csrf import csrf_exempt

--- a/cove/management/commands/tests.py
+++ b/cove/management/commands/tests.py
@@ -13,7 +13,7 @@ def test_expire_files():
     recent.original_file.save('test.json', ContentFile('{}'))
 
     old = SuppliedData.objects.create()
-    old.created = timezone.datetime(2015, 1, 1)
+    old.created = timezone.datetime(2015, 1, 1, tzinfo=timezone.utc)
     old.original_file.save('test.json', ContentFile('{}'))
 
     call_command('expire_files')
@@ -26,7 +26,7 @@ def test_expire_files_default_days(settings):
     del(settings.DELETE_FILES_AFTER_DAYS)
 
     old = SuppliedData.objects.create()
-    old.created = timezone.datetime.now() - datetime.timedelta(days=30)
+    old.created = timezone.now() - datetime.timedelta(days=30)
     old.original_file.save('test.json', ContentFile('{}'))
     call_command('expire_files')
     assert not os.path.exists(old.upload_dir())
@@ -37,7 +37,7 @@ def test_expire_files_90_days(settings):
     settings.DELETE_FILES_AFTER_DAYS = 90
 
     old = SuppliedData.objects.create()
-    old.created = timezone.datetime.now() - datetime.timedelta(days=30)
+    old.created = timezone.now() - datetime.timedelta(days=30)
     old.original_file.save('test.json', ContentFile('{}'))
     call_command('expire_files')
     assert os.path.exists(old.upload_dir())

--- a/cove/templates/base.html
+++ b/cove/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-{% load static from staticfiles %}
+{% load static %}
 {% load bootstrap3 %}
 {% load i18n %}
 <html>

--- a/cove/urls.py
+++ b/cove/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.contrib import admin
 from django.conf import settings
 from django.views.generic import TemplateView
@@ -28,10 +28,10 @@ def cause500(request):
 
 
 urlpatterns = [
-    url(r'^$', cove.input.views.data_input, name='index'),
-    url(r'^terms/$', TemplateView.as_view(template_name='terms.html'), name='terms'),
-    url(r'^stats/$', cove.views.stats, name='stats'),
-    url(r'^test/500$', cause500),
-    url(r'^admin/', admin.site.urls),
-    url(r'^i18n/', include('django.conf.urls.i18n'))
+    re_path(r'^$', cove.input.views.data_input, name='index'),
+    re_path(r'^terms/$', TemplateView.as_view(template_name='terms.html'), name='terms'),
+    re_path(r'^stats/$', cove.views.stats, name='stats'),
+    re_path(r'^test/500$', cause500),
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^i18n/', include('django.conf.urls.i18n'))
 ]

--- a/cove/views.py
+++ b/cove/views.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from django.db.models.aggregates import Count
 from django.shortcuts import render
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils import timezone
 from django.core.exceptions import ValidationError
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
     ],
     install_requires=[
-        "Django<2.3",
+        "Django>=2.2,<3.3",
         "django-bootstrap3",
         "django-debug-toolbar",
         "requests",

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,6 @@ setup(
         "rfc3987",
         "uc-rfc6266-parser",
         "xmltodict",
-        # libcove deps on flatten-tool which pulls in openpyxl
-        # which is only compatible with certain versions of python
-        "openpyxl==2.6.4",
         "libcove>=0.17.0",
     ],
     extras_require={


### PR DESCRIPTION
All changes are backwards-compatible with 2.2.

* gettext_lazy: https://docs.djangoproject.com/en/2.2/topics/i18n/translation/
* re_path: https://docs.djangoproject.com/en/2.2/ref/urls/#django.urls.re_path
* static: https://docs.djangoproject.com/en/2.2/howto/static-files/