### PR TITLE
settings: Do not warn if SECRET_KEY is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+# [0.24.2] - 2021-11-18
+
+- Do not warn if `SECRET_KEY` is not set in settings
+
 # [0.24.1] - 2021-05-25
 
 ### Fixed

--- a/cove/settings.py
+++ b/cove/settings.py
@@ -27,8 +27,6 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#%^&*(-_=+)'
 secret_key = get_random_string(50, chars)
-if 'SECRET_KEY' not in os.environ:
-    warnings.warn('SECRET_KEY should be added to Environment Variables. Random key will be used instead.')
 
 env = environ.Env(  # set default values and casting
     DEBUG=(bool, True),

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ install_requires = []
 
 setup(
     name='libcoveweb',
-    version='0.24.1',
+    version='0.24.2',
     author='Open Data Services',
     author_email='code@opendataservices.coop',
     packages=find_packages(),


### PR DESCRIPTION
In a test environment, the current code requires `SECRET_KEY` to be set if `PYTHONWARNINGS=error`, as otherwise the code issues a warning (which `PYTHONWARNINGS` changes to an error, causing tests to fail).

Our CI tests use `PYTHONWARNINGS=error` so that any warnings from `migrate`, `makemigrations --check`, etc. cause CI to fail.

However, it's a bit annoying to have to set `SECRET_KEY`.

lib-cove-web should not be so concerned with core Django features. It is up to the user to deploy Django correctly.