### PR TITLE
fix: Use FieldFile.path instead of File.name, to avoid unclosed file warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         django-version:
           - "Django>=2.2,<2.3"
           - "Django>=3.0,<3.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - run: "pip install --upgrade pip"
-      - run: "pip install --use-feature=2020-resolver --upgrade -e .[test]"
+      - run: "pip install --upgrade -e .[test]"
       - run: "pip install '${{ matrix.django-version }}'"
       - run: "py.test -n 2 cove --cov"
         env:

--- a/cove/views.py
+++ b/cove/views.py
@@ -79,7 +79,7 @@ def explore_data_context(request, pk, get_file_type=None):
             }, status=404)
 
     try:
-        file_name = data.original_file.file.name
+        file_name = data.original_file.path
         if file_name.endswith('validation_errors-3.json'):
             raise PermissionError('You are not allowed to upload a file with this name.')
     except FileNotFoundError:


### PR DESCRIPTION
Otherwise I get failures when running with `pytest -W` like:

```
tests/test_basic.py ...E                                                 [ 80%]
Exception ignored in: <_io.FileIO name='/home/runner/work/cove-oc4ids/cove-oc4ids/media/d79f724e-4217-4432-8728-a5222bc1517f/test.json' mode='rb' closefd=True>
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/tokenize.py", line 528, in _tokenize
    spos, epos, pos = (lnum, start), (lnum, end), end
ResourceWarning: unclosed file <_io.BufferedReader name='/home/runner/work/cove-oc4ids/cove-oc4ids/media/d79f724e-4217-4432-8728-a5222bc1517f/test.json'>
Exception ignored in: <socket.socket fd=14, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 53186), raddr=('127.0.0.1', 52031)>
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/tokenize.py", line 528, in _tokenize
    spos, epos, pos = (lnum, start), (lnum, end), end
ResourceWarning: unclosed <socket.socket fd=14, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 53186), raddr=('127.0.0.1', 52031)>
```

Note to myself to remove `STANDARD_MAINTENANCE_SCRIPTS_IGNORE` from `lint.yml` in cove-oc4ids and cove-ocds after upgrading to a new release of libcoveweb.