### PR TITLE
fix: Use FieldFile.path instead of File.name, to avoid unclosed file warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Switch to Werkzeug from uc-rfc6266-parser
 - Drop Python 3.6 support
+- Use FieldFile.path instead of File.name, to avoid unclosed file warnings
 
 # [0.25.0] - 2022-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+# [0.26.0] - 2023-02-17
+
 ## Changed
 
 - Switch to Werkzeug from uc-rfc6266-parser

--- a/cove/views.py
+++ b/cove/views.py
@@ -79,7 +79,7 @@ def explore_data_context(request, pk, get_file_type=None):
             }, status=404)
 
     try:
-        file_name = data.original_file.file.name
+        file_name = data.original_file.path
         if file_name.endswith('validation_errors-3.json'):
             raise PermissionError('You are not allowed to upload a file with this name.')
     except FileNotFoundError:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ install_requires = []
 
 setup(
     name='libcoveweb',
-    version='0.25.0',
+    version='0.26.0',
     author='Open Data Services',
     author_email='code@opendataservices.coop',
     packages=find_packages(),


### PR DESCRIPTION
https://github.com/OpenDataServices/lib-cove-web/pull/108 rebased.