### PR TITLE
fix: Use werkzeug directly instead of uc-rfc6266-parser, to apply security updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Changed
 
-* Drop Python 3.6 support
+- Switch to Werkzeug from uc-rfc6266-parser
+- Drop Python 3.6 support
 
 # [0.25.0] - 2022-07-19
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "requests",
         "django-environ",
         "flattentool",
-        "uc-rfc6266-parser",
+        "werkzeug",
         "libcove>=0.17.0",
     ],
     extras_require={


### PR DESCRIPTION
uc-rfc6266-parser depends on werkzeug, but I'm quite sure uc-rfc6266-parser is not maintained (just like rfc6266-parser was not maintained, and rfc6266 before that).

I kept the same logic as:

https://github.com/genme/python-rfc6266-parser/blob/3a7f39db61eb1dbda9be6568150e75b7a805f050/rfc6266_parser.py#L209-L214

and https://github.com/genme/python-rfc6266-parser/blob/3a7f39db61eb1dbda9be6568150e75b7a805f050/rfc6266_parser.py#L148

and https://github.com/genme/python-rfc6266-parser/blob/3a7f39db61eb1dbda9be6568150e75b7a805f050/rfc6266_parser.py#L61-L85