### PR TITLE
feat: Add Django 4.2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Add
+
+- Support Django 4.2 https://github.com/OpenDataServices/lib-cove-web/issues/112
+
 # [0.27.0] - 2023-03-06
 
 ## Changed

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     python_requires=">=3.7",
     install_requires=[
-        "Django>=2.2,<3.3",
+        "Django>=2.2",
         "django-bootstrap3",
         "requests",
         "django-environ",


### PR DESCRIPTION
closes #112 (yes, Django 4.2 will work out of the box, as lib-cove-web has no deprecations that would be removed in 4.2).