### PR TITLE
input: Add disable direct web fetch by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.30.5] - 2024-09-30
+
 ### Added
 
+- New setting `allow_direct_web_fetch` to configure whether cove will fetch any url passed as a GET parameter rather than from the input form. The default will be for this to be disabled. Cove implementations updating may need to check if there are "try this sample data" links on the home page that will need to be updated to use a form with newly required CSRF protection (For example - https://github.com/OpenDataServices/lib-cove-web/pull/144#issuecomment-2378743354).
 - Set the `REQUESTS_TIMEOUT` setting, to prevent source URLs from causing a denial of service, whether accidentally or maliciously.
 
 ## [0.30.4] - 2024-06-28

--- a/cove/input/views.py
+++ b/cove/input/views.py
@@ -8,7 +8,7 @@ from django.shortcuts import render, redirect
 from django.utils.translation import gettext_lazy as _
 
 from cove.input.models import SuppliedData
-from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.csrf import csrf_protect
 
 
 class UploadForm(forms.ModelForm):
@@ -40,11 +40,11 @@ default_form_classes = {
 }
 
 
-@csrf_exempt
+@csrf_protect
 def data_input(request, form_classes=default_form_classes, text_file_name='test.json'):
     forms = {form_name: form_class() for form_name, form_class in form_classes.items()}
     request_data = None
-    if "source_url" in request.GET:
+    if "source_url" in request.GET and settings.COVE_CONFIG.get("allow_direct_web_fetch", False):
         request_data = request.GET
     if request.POST:
         request_data = request.POST

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ install_requires = []
 
 setup(
     name='libcoveweb',
-    version='0.30.4',
+    version='0.30.5',
     author='Open Data Services',
     author_email='code@opendataservices.coop',
     packages=find_packages(),


### PR DESCRIPTION
This adds the setting `allow_direct_web_fetch` which configures whether the functionality to allow using a web direct fetch i.e. not via a form on the frontend but via a direct GET parameter to be fetched from will be allowed.

Re-instate csrf_protect